### PR TITLE
Add SQLite persistence for map comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# cbsTest
+# Map Comments Application
+
+This simple app allows users to select locations on a map and leave comments. Other users connected to the app will see new comments appear in real time.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install express socket.io sqlite3
+   ```
+2. Start the server:
+   ```bash
+   node server.js
+   ```
+3. Open `http://localhost:3000` in your browser.
+
+Click anywhere on the map to add a comment. Comments from all users are stored in a local SQLite database (`comments.db`) so that they persist between server restarts.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Map Comments App</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <style>
+        #map { height: 100vh; }
+        .leaflet-popup-content-wrapper {
+            overflow: visible;
+        }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
+    <script>
+        const map = L.map('map').setView([0, 0], 2);
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '© OpenStreetMap'
+        }).addTo(map);
+
+        const socket = io();
+
+        // existing comments
+        socket.on('existing-comments', comments => {
+            comments.forEach(addCommentToMap);
+        });
+
+        socket.on('new-comment', data => {
+            addCommentToMap(data);
+        });
+
+        function addCommentToMap(data) {
+            L.marker([data.lat, data.lng]).addTo(map)
+                .bindPopup(`<b>${data.comment}</b>`);
+        }
+
+        map.on('click', function(e) {
+            const comment = prompt('Enter your comment:');
+            if(comment) {
+                const data = { lat: e.latlng.lat, lng: e.latlng.lng, comment };
+                socket.emit('add-comment', data);
+                addCommentToMap(data);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cbstest",
+  "version": "1.0.0",
+  "description": "This simple app allows users to select locations on a map and leave comments. Other users connected to the app will see new comments appear in real time.",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "socket.io": "^4.7.2",
+    "sqlite3": "^5.1.6"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const http = require('http');
+const socketIo = require('socket.io');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const app = express();
+const server = http.createServer(app);
+const io = socketIo(server);
+
+// Initialize SQLite database in the project directory
+const db = new sqlite3.Database(path.join(__dirname, 'comments.db'));
+
+db.serialize(() => {
+    db.run(
+        'CREATE TABLE IF NOT EXISTS comments (id INTEGER PRIMARY KEY AUTOINCREMENT, lat REAL, lng REAL, comment TEXT)'
+    );
+});
+
+app.use(express.static(__dirname));
+
+io.on('connection', socket => {
+    // Send all existing comments to the newly connected client
+    db.all('SELECT lat, lng, comment FROM comments', [], (err, rows) => {
+        if (err) {
+            console.error(err);
+            return;
+        }
+        socket.emit('existing-comments', rows);
+    });
+
+    // Save new comments to the database and broadcast to other clients
+    socket.on('add-comment', data => {
+        db.run(
+            'INSERT INTO comments (lat, lng, comment) VALUES (?, ?, ?)',
+            [data.lat, data.lng, data.comment],
+            err => {
+                if (err) {
+                    console.error(err);
+                    return;
+                }
+                socket.broadcast.emit('new-comment', data);
+            }
+        );
+    });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- switch from in-memory storage to SQLite database
- update README instructions
- define dependencies in `package.json`

## Testing
- `npm install express socket.io sqlite3` *(fails: 403 Forbidden)*
- `node server.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_685e57f29a94832aada42a73a3ac62df